### PR TITLE
add base code for Chrome extension

### DIFF
--- a/UrlParamsChromeExtension/manifest.json
+++ b/UrlParamsChromeExtension/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "Url Params",
+  "version": "0.0.1",
+  "description": "View and edit url params for the current tab.",
+  "permissions": [
+    "activeTab"
+  ],
+  "options_page": "options.html",
+  "browser_action": {
+    "default_popup": "popup.html"
+  },
+  "manifest_version": 2
+}

--- a/UrlParamsChromeExtension/options.html
+++ b/UrlParamsChromeExtension/options.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <style></style>
+</head>
+
+<body>
+  <div id="url-params-options">
+    <h1>Url Params Options</h1>
+  </div>
+</body>
+<script src="options.js"></script>
+
+</html>

--- a/UrlParamsChromeExtension/options.js
+++ b/UrlParamsChromeExtension/options.js
@@ -1,0 +1,6 @@
+'use strict';
+
+function constructOptions() {
+  console.log('constructOptions was called');
+}
+constructOptions();

--- a/UrlParamsChromeExtension/popup.html
+++ b/UrlParamsChromeExtension/popup.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <style>
+    body {
+      overflow-wrap: break-word;
+    }
+  </style>
+</head>
+
+<body>
+
+  <div class="url-params-popup" id="url-params-popup">
+    <h1>Url Params Popup</h1>
+    <div id="url-params-popup-url">
+      <h2>URL</h2>
+    </div>
+    <div id="url-params-popup-search-params">
+      <h2>Search params:</h2>
+    </div>
+  </div>
+  <script src="popup.js"></script>
+</body>
+
+</html>

--- a/UrlParamsChromeExtension/popup.js
+++ b/UrlParamsChromeExtension/popup.js
@@ -1,0 +1,20 @@
+'use strict';
+
+function getUrlParams() {
+  chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+    const url = tabs[0].url;
+    const urlObj = new URL(tabs[0].url);
+    const searchParams = new URLSearchParams(urlObj.search);
+
+    const wholeUrlDiv = document.getElementById("url-params-popup-url");
+    wholeUrlDiv.innerHTML += url;
+
+    const searchParamsDiv = document.getElementById("url-params-popup-search-params");
+    searchParamsDiv.innerHTML += "<ul>";
+    for (let [key, value] of searchParams.entries()) {
+      searchParamsDiv.innerHTML += `<li><b>${key}:</b> ${value}`;
+    }
+    searchParamsDiv.innerHTML += "</ul>";
+  });
+};
+getUrlParams();


### PR DESCRIPTION
This PR adds working base code for Chrome extension:

- full url is shown
- search (query) params are shown as an unordered list